### PR TITLE
tagとpostを紐付ける中間テーブルのモデルを追加

### DIFF
--- a/src/app/Models/PostTag.php
+++ b/src/app/Models/PostTag.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+
+class PostTag extends Model
+{
+    use HasUuids;
+
+    protected $fillable = ['post_id', 'tag_id'];
+}


### PR DESCRIPTION
# Overview

![スクリーンショット 2023-07-18 12 20 12](https://github.com/kirikirisu/kenshu_backend_laravel/assets/38555478/3165d9d0-31a2-4408-969d-8d46d8dd9c24)
